### PR TITLE
[bugfix] resource-retry

### DIFF
--- a/tasks/project-resources.yml
+++ b/tasks/project-resources.yml
@@ -24,7 +24,7 @@
       }}
   when: provision_action != 'ignore'
   register: provision
-  until: provision.rc == 0
+  until: provision | success
   retries: 3
   delay: 10
   changed_when: >-


### PR DESCRIPTION
adding retry section for resource which is dependent on other resources and wasn't able to be created as dependent resource wasn't ready.