### PR TITLE
make generate_resources optional and default false

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,5 @@ openshift_resource_path:
 openshift_provision_change_record: ''
 
 openshift_provision_cluster_vars: {}
+
+generate_resources: false

--- a/library/openshift_provision.py
+++ b/library/openshift_provision.py
@@ -1520,6 +1520,7 @@ def run_module():
         # Use role as resource generator instead of provisioner
         'generate_resources': {
             'type': 'bool',
+            'required': False,
             'default': False
         }
     }


### PR DESCRIPTION
I was getting errors that `generate_resources` was not defined when it was not passed in as true or false to the role, so a default value was needed.