### PR TITLE
bugfix: properly retrieve the openshift version

### DIFF
--- a/tasks/openshift-cluster.yml
+++ b/tasks/openshift-cluster.yml
@@ -45,7 +45,7 @@
     openshift-3-version-facts.yml
     {%- endif %}
   vars:
-    oc_version_output: get_version.stdout
+    oc_version_output: "{{ get_version.stdout }}"
 
 - name: Get cluster-vars configmap from kube-public
   command: >-


### PR DESCRIPTION
oc_version_output was being set to the string "get_version.stdout"
rather than the value of the variable "get_version.stdout". This was
causing the values of "openshift_provision_oc_version" and
"openshift_provision_openshift_version" to be set to the string
"get_version.stdout" which is not correct.

Fixes #17