### PR TITLE
bugfix: use resource fqdn when running patch and delete

### DIFF
--- a/library/openshift_provision.py
+++ b/library/openshift_provision.py
@@ -1465,13 +1465,14 @@ class OpenShiftProvision:
             return
 
         # Perform action on resource
+        resource_fqdn = self.resource['kind'] + "." + self.resource['apiVersion'].split("/")[0]
         if self.action == 'delete':
-            command = ['delete', self.resource['kind'], self.resource['metadata']['name']]
+            command = ['delete', resource_fqdn, self.resource['metadata']['name']]
             if self.namespace:
                 command += ['-n', self.namespace]
             (rc, stdout, stderr) = self.run_oc(command, check_rc=True)
         elif self.action == 'patch':
-            command = ['patch', self.resource['kind'], self.resource['metadata']['name'],
+            command = ['patch', resource_fqdn, self.resource['metadata']['name'],
                 '--patch=' + json.dumps(self.resource),
                 '--type=' + self.patch_type
             ]


### PR DESCRIPTION
If there are multiple resources with the same `Kind` but are part of
different API groups, you have to provide the API group and the Kind
in the format `kind.apigroup` to ensure the correct resource is
modified.

For example, in OpenShift 4.x, there are `configs.operator.openshift.io`
and `configs.imageregistry.operator.openshift.io` resources. If you
try to run `oc patch configs cluster...`, the API call would not know for
sure if you were trying to patch the image registry config, or the
operator config and can fail.

To prevent issues, you can provide the full resource kind in your
command, for example to patch the image registry, you should use
`oc patch configs.imageregistry.operator.openshift.io cluster...`

Fixes #19