### PR TITLE
Provision retry limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,16 @@ Top level definition of how to manage a cluster:
 * `provision_pre_tasks` - List of ansible tasks files to include immediately
   before processing provision for this cluster
 
+* `provision_retry_limit` - Number of times to attempt to reapply resources.
+  Defaults to 0.  
+  NOTE: Setting this to anything greater than 0 will cause ansible to report
+  failed tasks in the play recap when retries are needed. However, ansible will
+  still exit successfully if all resources were able to provision within the
+  retry limit.
+
+* `provision_retry_wait_seconds` - Number of seconds to wait before reapplying
+  resources.  Defaults to 5
+
 * `resource_path` - List of paths to search for resource definitons specified
   by relative file path under `cluster_resources` and `resources`, defaults
   to value of `openshift_resource_path`

--- a/tasks/cluster-resources.yml
+++ b/tasks/cluster-resources.yml
@@ -16,7 +16,7 @@
   loop_control:
     loop_var: resource
     label:
-      - Resource_kind - "{{ resource.kind }}"
+      - Resource_kind - "{{ resource.kind }} ({{ resource.apiVersion }})"
       - Resource_name  - "{{ resource.metadata.name }}"
   vars:
     provision_action: >-

--- a/tasks/cluster-resources.yml
+++ b/tasks/cluster-resources.yml
@@ -29,3 +29,10 @@
   register: provision
   changed_when: >-
     provision | record_change_provision(change_record)
+  ignore_errors: True
+- set_fact:
+    provision_failures: "{{ provision_failures + provision.results }}"
+  when: "'failed' in provision and 'results' in provision"
+- set_fact:
+    provision_failures_skipped: "{{ provision_failures_skipped + [provision] }}"
+  when: "'results' not in provision"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 # Process openshift resources
+- set_fact:
+    provision_retry_limit: "{{ 0 if provision_retry_limit is undefined else provision_retry_limit }}"
+    provision_retry_wait_seconds: "{{ 5 if provision_retry_wait_seconds is undefined else provision_retry_wait_seconds }}"
 - name: Handle openshift_clusters
   include_tasks: openshift-cluster.yml
   with_items: >-

--- a/tasks/openshift-cluster-provision.yml
+++ b/tasks/openshift-cluster-provision.yml
@@ -2,71 +2,79 @@
 # Process cluster_resources before processing other items, including projects.
 # This allows items like cluster roles to be defined within cluster_resources.
 
-- name: Handle cluster_resources
-  include_tasks: cluster-resources.yml
-  with_items: "{{ openshift_cluster.cluster_resources | default([]) }}"
-  vars:
-    resource_path: "{{ openshift_cluster.resource_path | default(openshift_resource_path) }}"
-    resource_list: >-
-      {%- if resource_item is mapping -%}
-      {{ [resource_item] }}
-      {%- else -%}
-      {{ lookup(
-           'template' if resource_item.endswith('.j2') else 'file',
-           lookup('first_found', {'files':resource_item, 'paths': resource_path})
-         ) | yaml_to_resource_list
-      }}
-      {%- endif -%}
-  loop_control:
-    loop_var: resource_item
+- name: openshift-cluster-provision
+  block:
+  - name: clear failures
+    set_fact:
+      provision_failures: []
+      provision_failures_skipped: []
+  - name: init retry count
+    set_fact:
+      retry_count: 0
 
-- name: Handle cluster process_templates
-  include_tasks: process-template.yml
-  with_items: "{{ openshift_cluster.process_templates | default([]) }}"
-  loop_control:
-    loop_var: template
+  - name: Handle cluster_resources
+    include_tasks: cluster-resources.yml
+    with_items: "{{ openshift_cluster.cluster_resources | default([]) }}"
+    vars:
+      resource_path: "{{ openshift_cluster.resource_path | default(openshift_resource_path) }}"
+      resource_list: >-
+        {%- if resource_item is mapping -%}
+        {{ [resource_item] }}
+        {%- else -%}
+        {{ lookup(
+            'template' if resource_item.endswith('.j2') else 'file',
+            lookup('first_found', {'files':resource_item, 'paths': resource_path})
+          ) | yaml_to_resource_list
+        }}
+        {%- endif -%}
+    loop_control:
+      loop_var: resource_item
 
-- name: Handle cluster helm_charts
-  include_tasks: helm-chart.yml
-  with_items: "{{ openshift_cluster.helm_charts | default([]) }}"
-  loop_control:
-    loop_var: helm_chart
+  - name: Handle cluster process_templates
+    include_tasks: process-template.yml
+    with_items: "{{ openshift_cluster.process_templates | default([]) }}"
+    loop_control:
+      loop_var: template
 
-- name: Handle groups
-  include_tasks: group.yml
-  with_items: "{{ openshift_cluster.groups | default([]) }}"
-  loop_control:
-    loop_var: group
+  - name: Handle cluster helm_charts
+    include_tasks: helm-chart.yml
+    with_items: "{{ openshift_cluster.helm_charts | default([]) }}"
+    loop_control:
+      loop_var: helm_chart
 
-- name: Handle cluster_role_bindings
-  include_tasks: cluster-role-bindings.yml
-  when: openshift_cluster.cluster_role_bindings is defined
+  - name: Handle groups
+    include_tasks: group.yml
+    with_items: "{{ openshift_cluster.groups | default([]) }}"
+    loop_control:
+      loop_var: group
 
-- name: Handle projects
-  include_tasks: project.yml
-  with_items: "{{ openshift_cluster.projects | default([]) }}"
-  loop_control:
-    loop_var: project
-  vars:
-    cluster_resource_path: "{{ openshift_cluster.resource_path | default(openshift_resource_path) }}"
+  - name: Handle cluster_role_bindings
+    include_tasks: cluster-role-bindings.yml
+    when: openshift_cluster.cluster_role_bindings is defined
 
-# Process resources after processing other items such as projects. This
-# allows creation of resources in multiple projects in a specific order by
-# specifying the namespace in the resource metadata.
-- name: Handle cluster level resources
-  include_tasks: cluster-resources.yml
-  with_items: "{{ openshift_cluster.cluster_resources | default([]) }}"
-  vars:
-    resource_path: "{{ openshift_cluster.resource_path | default(openshift_resource_path) }}"
-    resource_list: >-
-      {%- if resource_item is mapping -%}
-      {{ [resource_item] }}
-      {%- else -%}
-      {{ lookup(
-           'template' if resource_item.endswith('.j2') else 'file',
-           lookup('first_found', {'files':resource_item, 'paths': resource_path})
-         ) | yaml_to_resource_list
-      }}
-      {%- endif -%}
-  loop_control:
-    loop_var: resource_item
+  - name: Handle projects
+    include_tasks: project.yml
+    with_items: "{{ openshift_cluster.projects | default([]) }}"
+    loop_control:
+      loop_var: project
+    vars:
+      cluster_resource_path: "{{ openshift_cluster.resource_path | default(openshift_resource_path) }}"
+
+  - name: Check for failures
+    fail:
+      msg: "{{ provision_failures }}"
+    when: provision_failures | length > 0
+
+  rescue:
+  - name: Check retry limit
+    fail:
+      msg: "Maximum retries reached ({{ provision_retry_limit }})"
+    when: (retry_count | int) >= (provision_retry_limit | int)
+
+  - include_tasks: provision-retry.yml
+
+  always:
+  - name: Check unhandled failures
+    fail:
+      msg: "{{ provision_failures_skipped }}"
+    when: provision_failures_skipped | length > 0

--- a/tasks/project-resources.yml
+++ b/tasks/project-resources.yml
@@ -18,7 +18,7 @@
     loop_var: resource
     label:
       - Namespace - "{{ project.name }}"
-      - Resource_kind - "{{ resource.kind }}"
+      - Resource_kind - "{{ resource.kind }} ({{ resource.apiVersion }})"
       - Resource_name  - "{{ resource.metadata.name }}"
   vars:
     provision_action: >-

--- a/tasks/project-resources.yml
+++ b/tasks/project-resources.yml
@@ -31,3 +31,10 @@
   register: provision
   changed_when: >-
     provision | record_change_provision(change_record)
+  ignore_errors: True
+- set_fact:
+    provision_failures: "{{ provision_failures + provision.results }}"
+  when: "'failed' in provision and 'results' in provision"
+- set_fact:
+    provision_failures_skipped: "{{ provision_failures_skipped + [provision] }}"
+  when: "'results' not in provision"

--- a/tasks/provision-retry.yml
+++ b/tasks/provision-retry.yml
@@ -1,0 +1,64 @@
+---
+- name: provision-retry
+  block:
+  - name: increment retry count
+    set_fact:
+      retry_count: "{{ retry_count | int + 1 }}"
+  - pause:
+      seconds: "{{ provision_retry_wait_seconds }}"
+    when: (provision_retry_wait_seconds | int) > 0
+
+  - name: "retry provisioning resources (attempt {{ retry_count }})"
+    openshift_provision:
+      action: "{{ provision_args.action | default(omit) }}"
+      patch_type: "{{ provision_args.patch_type | default(omit) }}"
+      connection: "{{ provision_args.connection | default(omit) }}"
+      resource: "{{ provision_resource }}"
+      generate_resources: "{{ provision_args.generate_resources | default(omit) }}"
+      fail_on_change: "{{ provision_args.fail_on_change | default(omit) }}"
+      namespace: "{{ provision_args.namespace | default(omit) }}"
+    with_items: "{{ provision_failures }}"
+    loop_control:
+      loop_var: provision_failure
+      label:
+      - Resource_kind - "{{ provision_resource.kind | default('', true) }}"
+      - Resource_namespace - "{{ provision_args.namespace | default('<none>', true) }}"
+      - Resource_name - "{{ provision_resource.metadata.name | default('', true) }}"
+    vars:
+      provision_args: "{{ provision_failure.invocation.module_args | default({}, true) }}"
+      provision_resource: "{{ provision_failure.resource | default({}, true) }}"
+    when: provision_failure.failed | default(false, true)
+    register: provision_retry_status
+    ignore_errors: True
+
+  # Reset provision failures
+  - name: Clear failed resources
+    set_fact:
+      provision_failures: []
+  - name: Record new failures
+    set_fact:
+      provision_failures: "{{ provision_failures + [provision_failure] }}"
+    with_items: "{{ provision_retry_status.results }}"
+    loop_control:
+      label:
+      - Resource_kind - "{{ provision_resource.kind | default('', true) }} ({{ provision_resource.apiVersion | default('', true) }})"
+      - Resource_namespace - "{{ provision_args.namespace | default('<none>', true) }}"
+      - Resource_name - "{{ provision_resource.metadata.name | default('', true) }}"
+    vars:
+      provision_failure: "{{ item.provision_failure }}"
+      provision_args: "{{ item.provision_failure.invocation.module_args | default({}, true) }}"
+      provision_resource: "{{ item.provision_failure.resource | default({}, true) }}"
+    when: item.failed | default(false, true)
+
+  - name: Check for failures
+    fail:
+      msg: "{{ provision_failures }}"
+    when: provision_failures | length > 0
+
+  rescue:
+  - name: Check retry limit
+    fail:
+      msg: "Maximum retries reached ({{ provision_retry_limit }})"
+    when: (retry_count | int) >= (provision_retry_limit | int)
+
+  - include_tasks: provision-retry.yml


### PR DESCRIPTION
Adds a new role parameter `provision_retry_limit` that will be used when checking failures during resource provisioning. Right now it only affects cluster resources and project resources, but could be extended to other resources as well. The primary purpose of this is to allow resources to be declared out of order, like CRs before CRDs.

When `provision_retry_limit` is higher than 0, the default, the role will try to provision all the resources it can before going into a loop to reapply any failed resources. Before each reapplication attempt, the role will wait `provision_retry_wait_seconds`. When the attempt is complete, it will check if any failures were recorded, then retry the failed resources in the same manner until either no more failures are recorded or the retry limit is reached.