### PR TITLE
Bugfix: Allow retries on existing resources

### DIFF
--- a/library/openshift_provision.py
+++ b/library/openshift_provision.py
@@ -1111,7 +1111,10 @@ class OpenShiftProvision:
         (rc, stdout, stderr) = self.module.run_command(self.oc_cmd + args, **kwargs)
 
         if rc != 0 and check_rc:
-            self.module.fail_json(cmd=args, rc=rc, stdout=stdout, stderr=stderr, msg=stderr)
+            self.module.fail_json(
+                cmd=args, rc=rc, stdout=stdout, stderr=stderr, msg=stderr,
+                resource=self.resource, current_resource_version=self.current_resource_version
+            )
 
         return (rc, stdout, stderr)
 

--- a/library/openshift_provision.py
+++ b/library/openshift_provision.py
@@ -1386,23 +1386,11 @@ class OpenShiftProvision:
 
         metadata = resource.get('metadata', {})
         resource_version = metadata \
-            .get('resourceVersion', None)
+            .pop('resourceVersion', None)
         last_applied_configuration = metadata \
             .get('annotations', {}) \
-            .get('kubectl.kubernetes.io/last-applied-configuration', None)
+            .pop('kubectl.kubernetes.io/last-applied-configuration', None)
         return resource_version, last_applied_configuration
-
-    def set_resource_version_and_last_applied_configuration(self, resource_version, last_applied_configuration):
-        if not resource_version or not last_applied_configuration:
-            return
-        merge_dict(self.resource, {
-            'metadata': {
-                'annotations': {
-                    'kubectl.kubernetes.io/last-applied-configuration': last_applied_configuration
-                },
-                'resourceVersion': resource_version
-            }
-        }, overwrite=True)
 
     def provision(self):
         current_resource = self.get_current_resource()
@@ -1410,6 +1398,7 @@ class OpenShiftProvision:
             self.get_resource_version_and_last_applied_configuration(current_resource)
         if current_resource and self.action in ['apply', 'replace']:
             self.set_dynamic_values(current_resource)
+        self.current_resource_version = current_resource_version
 
         # Check if changes are required and if we need to reset the apply metadata.
         reset_last_applied_configuration = False
@@ -1495,17 +1484,22 @@ class OpenShiftProvision:
                 command += ['-n', self.namespace]
             self.run_oc(command, data=json.dumps(self.resource), check_rc=True)
         else: # apply, create, delete, replace
+            resource = copy.deepcopy(self.resource)
             if self.action == 'apply':
-                self.set_resource_version_and_last_applied_configuration(
-                    current_resource_version,
-                    current_last_applied_configuration
-                )
+                merge_dict(resource, {
+                    'metadata': {
+                        'annotations': {
+                            'kubectl.kubernetes.io/last-applied-configuration': current_last_applied_configuration
+                        },
+                        'resourceVersion': current_resource_version
+                    }
+                })
             command = [self.action, '-f', '-']
             if self.namespace:
                 command += ['-n', self.namespace]
             if reset_last_applied_configuration:
                 command += ['--save-config']
-            self.run_oc(command, data=json.dumps(self.resource), check_rc=True)
+            self.run_oc(command, data=json.dumps(resource), check_rc=True)
 
 def run_module():
     module_args = {
@@ -1559,14 +1553,16 @@ def run_module():
             msg=str(e),
             action=provisioner.action,
             traceback=traceback.format_exc().split('\n'),
-            resource=provisioner.resource
+            resource=provisioner.resource,
+            current_resource_version=provisioner.current_resource_version
         )
 
     module.exit_json(
         action=provisioner.action,
         changed=provisioner.changed,
         patch=provisioner.patch,
-        resource=provisioner.resource
+        resource=provisioner.resource,
+        current_resource_version=provisioner.current_resource_version
     )
 
 def main():

--- a/library/openshift_provision.py
+++ b/library/openshift_provision.py
@@ -1487,7 +1487,7 @@ class OpenShiftProvision:
             self.run_oc(command, data=json.dumps(self.resource), check_rc=True)
         else: # apply, create, delete, replace
             resource = copy.deepcopy(self.resource)
-            if self.action == 'apply':
+            if self.action == 'apply' and current_resource_version:
                 merge_dict(resource, {
                     'metadata': {
                         'resourceVersion': current_resource_version

--- a/library/openshift_provision.py
+++ b/library/openshift_provision.py
@@ -1553,7 +1553,8 @@ def run_module():
             action=provisioner.action,
             traceback=traceback.format_exc().split('\n'),
             resource=provisioner.resource,
-            current_resource_version=provisioner.current_resource_version
+            current_resource_version=str(provisioner.current_resource_version or None),
+            jontest="Jon Test"
         )
 
     module.exit_json(
@@ -1561,7 +1562,8 @@ def run_module():
         changed=provisioner.changed,
         patch=provisioner.patch,
         resource=provisioner.resource,
-        current_resource_version=provisioner.current_resource_version
+        current_resource_version=str(provisioner.current_resource_version or None),
+        jontest="Jon Test"
     )
 
 def main():

--- a/library/openshift_provision.py
+++ b/library/openshift_provision.py
@@ -1122,7 +1122,9 @@ class OpenShiftProvision:
         command = ['get', self.resource['kind'], self.resource['metadata']['name'], '-o', 'json']
         if self.namespace:
             command += ['-n', self.namespace]
+        print("THIS IS THE COMMAND {}".format(" ".join(command)))
         (rc, stdout, stderr) = self.run_oc(command, check_rc=False)
+        print("THIS IS THE STDOUT {}".format(stdout))
         if rc != 0:
             return None
         resource = json.loads(stdout)
@@ -1297,8 +1299,6 @@ class OpenShiftProvision:
     def compare_resource(self, resource, compare_to=None):
         if compare_to == None:
             compare_to = self.resource
-        resource = copy.deepcopy(resource)
-        compare_to = copy.deepcopy(compare_to)
 
         config = self.normalize_resource(compare_to)
         current = self.normalize_resource(resource)

--- a/library/openshift_provision.py
+++ b/library/openshift_provision.py
@@ -1294,6 +1294,8 @@ class OpenShiftProvision:
     def compare_resource(self, resource, compare_to=None):
         if compare_to == None:
             compare_to = self.resource
+        resource = copy.deepcopy(resource)
+        compare_to = copy.deepcopy(compare_to)
 
         config = self.normalize_resource(compare_to)
         current = self.normalize_resource(resource)
@@ -1488,9 +1490,6 @@ class OpenShiftProvision:
             if self.action == 'apply':
                 merge_dict(resource, {
                     'metadata': {
-                        'annotations': {
-                            'kubectl.kubernetes.io/last-applied-configuration': current_last_applied_configuration
-                        },
                         'resourceVersion': current_resource_version
                     }
                 })

--- a/library/openshift_provision.py
+++ b/library/openshift_provision.py
@@ -1122,9 +1122,9 @@ class OpenShiftProvision:
         command = ['get', self.resource['kind'], self.resource['metadata']['name'], '-o', 'json']
         if self.namespace:
             command += ['-n', self.namespace]
-        print("THIS IS THE COMMAND {}".format(" ".join(command)))
         (rc, stdout, stderr) = self.run_oc(command, check_rc=False)
-        print("THIS IS THE STDOUT {}".format(stdout))
+        if self.resource['kind'] == "CertManager" and self.resource['metadata']['name'] == "cluster":
+            print("Resource stdout: {}".format(stdout))
         if rc != 0:
             return None
         resource = json.loads(stdout)


### PR DESCRIPTION
This PR fixes a bug where Ansible was retrying resources with a cached resourceVersion, so if the resourceVersion changed it would fall into a failure loop of not applying against the latest resourceVersion.

Now, Ansible will be using the latest resourceVersion when applying a resource.

Fixes: #33 