### PR TITLE
fix: flatten cluster_resources loop to prevent endswith error

### DIFF
--- a/tasks/openshift-cluster-provision.yml
+++ b/tasks/openshift-cluster-provision.yml
@@ -14,7 +14,7 @@
 
   - name: Handle cluster_resources
     include_tasks: cluster-resources.yml
-    loop: "{{ openshift_cluster.cluster_resources | default([]) }}"
+    loop: "{{ openshift_cluster.cluster_resources | default([]) | flatten }}"
     loop_control:
       loop_var: cluster_resource
     vars:


### PR DESCRIPTION
The data source is passing a nested list for cluster_resources. Ansible gets a list object instead of a string path, which breaks the .endswith() code check. We should flatten the list items down to a single layer so Ansible can read the text strings properly.